### PR TITLE
fix: Update code for Riverpod 3.0 compatibility

### DIFF
--- a/lib/src/paging_helper_view.dart
+++ b/lib/src/paging_helper_view.dart
@@ -27,9 +27,9 @@ final class PagingHelperView<D extends PagingData<I>, I>
     super.key,
   });
 
-  final ProviderListenable<AsyncValue<D>> provider;
-  final Refreshable<Future<D>> futureRefreshable;
-  final Refreshable<PagingNotifierMixin<D, I>> notifierRefreshable;
+  final dynamic provider;
+  final dynamic futureRefreshable;
+  final dynamic notifierRefreshable;
 
   /// Specifies a function that returns a widget to display when data is available.
   /// endItemView is a widget to detect when the last displayed item is visible.

--- a/lib/src/paging_notifier_mixin.dart
+++ b/lib/src/paging_notifier_mixin.dart
@@ -6,7 +6,7 @@ import 'package:riverpod_paging_utils/src/paging_data.dart';
 abstract interface class PagingNotifierMixin<D extends PagingData<T>, T> {
   AsyncValue<D> get state;
   set state(AsyncValue<D> newState);
-  Ref<AsyncValue<D>> get ref;
+  Ref get ref;
 
   Future<void> loadNext();
   void forceRefresh();
@@ -23,7 +23,7 @@ abstract mixin class PagePagingNotifierMixin<T>
   /// Loads the next page of data.
   @override
   Future<void> loadNext() async {
-    final value = state.valueOrNull;
+    final value = state.value;
     if (value == null) {
       return;
     }
@@ -64,7 +64,7 @@ abstract mixin class OffsetPagingNotifierMixin<T>
   /// Loads the next set of data based on the offset.
   @override
   Future<void> loadNext() async {
-    final value = state.valueOrNull;
+    final value = state.value;
     if (value == null) {
       return;
     }
@@ -105,7 +105,7 @@ abstract mixin class CursorPagingNotifierMixin<T>
   /// Loads the next set of data based on the cursor.
   @override
   Future<void> loadNext() async {
-    final value = state.valueOrNull;
+    final value = state.value;
     if (value == null) {
       return;
     }

--- a/test/paging_helper_view_test.dart
+++ b/test/paging_helper_view_test.dart
@@ -8,7 +8,7 @@ import 'package:riverpod_paging_utils/src/paging_notifier_mixin.dart';
 
 // Test notifier for widget tests
 class TestPagingNotifier
-    extends AutoDisposeAsyncNotifier<PagePagingData<String>>
+    extends AsyncNotifier<PagePagingData<String>>
     with PagePagingNotifierMixin<String> {
   @override
   Future<PagePagingData<String>> build() async {
@@ -42,7 +42,7 @@ class TestPagingNotifier
 
 // Test notifier that throws error on first page
 class TestErrorPagingNotifier
-    extends AutoDisposeAsyncNotifier<PagePagingData<String>>
+    extends AsyncNotifier<PagePagingData<String>>
     with PagePagingNotifierMixin<String> {
   @override
   Future<PagePagingData<String>> build() async {
@@ -66,7 +66,7 @@ class TestErrorPagingNotifier
 
 // Test notifier that throws error on second page
 class TestSecondPageErrorNotifier
-    extends AutoDisposeAsyncNotifier<PagePagingData<String>>
+    extends AsyncNotifier<PagePagingData<String>>
     with PagePagingNotifierMixin<String> {
   @override
   Future<PagePagingData<String>> build() async {
@@ -89,17 +89,17 @@ class TestSecondPageErrorNotifier
   }
 }
 
-final testPagingProvider = AutoDisposeAsyncNotifierProvider<TestPagingNotifier,
+final testPagingProvider = AsyncNotifierProvider<TestPagingNotifier,
     PagePagingData<String>>(() {
   return TestPagingNotifier();
 });
 
-final testErrorPagingProvider = AutoDisposeAsyncNotifierProvider<
+final testErrorPagingProvider = AsyncNotifierProvider<
     TestErrorPagingNotifier, PagePagingData<String>>(() {
   return TestErrorPagingNotifier();
 });
 
-final testSecondPageErrorProvider = AutoDisposeAsyncNotifierProvider<
+final testSecondPageErrorProvider = AsyncNotifierProvider<
     TestSecondPageErrorNotifier, PagePagingData<String>>(() {
   return TestSecondPageErrorNotifier();
 });
@@ -385,7 +385,7 @@ void main() {
 
     testWidgets('handles empty items list correctly', (tester) async {
       // Create a notifier that returns empty items
-      final emptyProvider = AutoDisposeAsyncNotifierProvider<EmptyItemsNotifier,
+      final emptyProvider = AsyncNotifierProvider<EmptyItemsNotifier,
           PagePagingData<String>>(() {
         return EmptyItemsNotifier();
       });
@@ -508,7 +508,7 @@ void main() {
 
 // Add empty items notifier for testing
 class EmptyItemsNotifier
-    extends AutoDisposeAsyncNotifier<PagePagingData<String>>
+    extends AsyncNotifier<PagePagingData<String>>
     with PagePagingNotifierMixin<String> {
   @override
   Future<PagePagingData<String>> build() async {

--- a/test/paging_notifier_mixin_test.dart
+++ b/test/paging_notifier_mixin_test.dart
@@ -181,7 +181,7 @@ void main() {
       expect(state.hasError, isTrue);
       expect(state.error.toString(), contains('Fetch error'));
       // Previous data should be preserved
-      expect(state.valueOrNull?.items, equals(['item1', 'item2', 'item3']));
+      expect(state.value?.items, equals(['item1', 'item2', 'item3']));
     });
 
     test('forceRefresh should clear state and invalidate', () {
@@ -240,7 +240,7 @@ void main() {
 
       final state = container.read(testPagePagingProvider);
       expect(state.isLoading, isTrue);
-      expect(state.valueOrNull, isNull);
+      expect(state.value, isNull);
     });
 
     test('loadNext should work correctly after error recovery', () async {
@@ -263,7 +263,7 @@ void main() {
       // Verify error state with preserved data
       var state = container.read(testPagePagingProvider);
       expect(state.hasError, isTrue);
-      expect(state.valueOrNull?.items, equals(['item1', 'item2', 'item3']));
+      expect(state.value?.items, equals(['item1', 'item2', 'item3']));
 
       // Fix the fetch function and retry
       notifier.fetchFunction = null; // Reset to default
@@ -344,7 +344,7 @@ void main() {
       expect(state.hasError, isTrue);
       expect(state.error.toString(), contains('Fetch error'));
       // Previous data should be preserved
-      expect(state.valueOrNull?.items, equals(['item1', 'item2', 'item3']));
+      expect(state.value?.items, equals(['item1', 'item2', 'item3']));
     });
 
     test('forceRefresh should clear state and invalidate', () {
@@ -434,7 +434,7 @@ void main() {
       expect(state.hasError, isTrue);
       expect(state.error.toString(), contains('Fetch error'));
       // Previous data should be preserved
-      expect(state.valueOrNull?.items, equals(['item1', 'item2', 'item3']));
+      expect(state.value?.items, equals(['item1', 'item2', 'item3']));
     });
 
     test('forceRefresh should clear state and invalidate', () {


### PR DESCRIPTION
## Summary
- Update existing code to be compatible with Riverpod 3.0 API changes
- Replace deprecated AutoDispose interfaces with standard ones
- Update method names to match new API

## Description
This PR is the third step in migrating `riverpod_paging_utils` to Riverpod 3.0. It updates all source code to be compatible with the breaking changes introduced in Riverpod 3.0.

### Changes Made

1. **Notifier Updates**
   - `AutoDisposeAsyncNotifier` → `AsyncNotifier`
   - `AutoDisposeAsyncNotifierProvider` → `AsyncNotifierProvider`

2. **API Updates**
   - `valueOrNull` → `value` (Riverpod 3.0 renamed this method)
   - Removed type parameter from `Ref` (now just `Ref` instead of `Ref<T>`)

3. **Type Compatibility**
   - Used dynamic types for provider parameters to avoid type resolution issues
   - This is a temporary solution pending further Riverpod 3.0 documentation

## Known Issues
- Generated files (`.g.dart`) need to be updated separately
- build_runner has compatibility issues with analyzer 7.0
- Some tests may fail until generated files are updated

## Test Plan
- [ ] Unit tests pass after generated files are updated
- [ ] Manual testing with example app
- [ ] No regression in existing functionality

## Next Steps
After this PR is merged:
- PR #4: Update and expand tests for Riverpod 3.0
- PR #5: Update example app

## Related
- Part of #[Issue Number] (Riverpod 3.0 Migration)
- Depends on: PR #45 (Dependency Updates)
- Next: PR #4 (Test Updates)

🤖 Generated with [Claude Code](https://claude.ai/code)